### PR TITLE
Fix project name spelling in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PortifolioSecondVersion
+# PortfolioSecondVersion
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 9.1.4.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  portifoliosecondversion:
+  portfoliosecondversion:
     build: .
     ports:
       - "8080:4200"


### PR DESCRIPTION
## Summary
- correct the project title in README
- update docker-compose service name to match

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e7989244832282cc003ccb061f6d