### PR TITLE
Update Angular tests for real DOM

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
+  it('should display page title', () => {
     page.navigateTo();
-    expect(page.getTitleText()).toEqual('PortifolioSecondVersion app is running!');
+    expect(page.getTitleText()).toEqual("Leo's Portfolio");
   });
 
   afterEach(async () => {

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -1,4 +1,4 @@
-import { browser, by, element } from 'protractor';
+import { browser } from 'protractor';
 
 export class AppPage {
   navigateTo(): Promise<unknown> {
@@ -6,6 +6,6 @@ export class AppPage {
   }
 
   getTitleText(): Promise<string> {
-    return element(by.css('app-root .content span')).getText() as Promise<string>;
+    return browser.getTitle() as Promise<string>;
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, async } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -7,6 +8,7 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      schemas: [NO_ERRORS_SCHEMA]
     }).compileComponents();
   }));
 
@@ -22,10 +24,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('PortifolioSecondVersion');
   });
 
-  it('should render title', () => {
+  it('should contain contact component', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('PortifolioSecondVersion app is running!');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-contact')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- update component unit test to check `<app-contact>` element
- use `browser.getTitle()` in e2e page object
- expect the page title in e2e spec

## Testing
- `npm test` *(fails: ng not found)*
- `npm run e2e` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e79a85048322a9d5421927e92bd2